### PR TITLE
[MVP] Alpha Release

### DIFF
--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -1,0 +1,78 @@
+import ldm_patched.modules.model_base
+import logging
+import torch
+
+class NRS:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { "model": ("MODEL",),
+                              "squash": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
+                              "stretch": ("FLOAT", {"default": 0.0, "min": -1.0, "max": 30.0, "step": 0.01}),
+                              }}
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "patch"
+
+    CATEGORY = "advanced/model"
+
+    def patch(self, model, squash, stretch):
+        def nrs(args):
+            cond = args["cond"]
+            uncond = args["uncond"]
+            cond_scale = args["cond_scale"]
+            sigma = args["sigma"]
+            sigma = sigma.view(sigma.shape[:1] + (1,) * (cond.ndim - 1))
+            x_orig = args["input"]
+
+            logging.debug(f"NRS.nrs: CFG: {cond_scale}, Squash: {squash}, Stretch: {stretch}")
+
+            #rescale cfg has to be done on v-pred model output
+            x = x_orig / (sigma * sigma + 1.0)
+            cond = ((x - (x_orig - cond)) * (sigma ** 2 + 1.0) ** 0.5) / (sigma)
+            uncond = ((x - (x_orig - uncond)) * (sigma ** 2 + 1.0) ** 0.5) / (sigma)
+            logging.debug(f"NRS.nrs: generated cond and uncond")
+
+            x_final = None
+            if False:
+                # displace cond by rejection of uncond on cond
+                u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                u_on_c = (u_dot_c / c_dot_c) * cond
+                u_rej_c = uncond - u_on_c
+                displaced = (cond - cond_scale * u_rej_c)
+                logging.debug(f"NRS.nrs: displaced")
+
+                # squash displaced vector towards len(cond) based on squash scale
+                sq_len = torch.sum(displaced * displaced, dim=-1, keepdim=True)
+                squash_scale = (1 - squash) + squash * ((c_dot_c/sq_len) ** 0.5)
+                squashed = displaced * squash_scale
+                logging.debug(f"NRS.nrs: squashed")
+
+                # stretch turned vector towards cond based on stretch scale
+                sq_dot_c = torch.sum(squashed * cond, dim=-1, keepdim=True)
+                sq_on_c = (sq_dot_c / c_dot_c) * cond
+                x_final = squashed + sq_on_c * stretch
+                logging.debug(f"NRS.nrs: final")
+            else:
+                # displace cond by rejection of uncond on cond
+                u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                u_on_c = (u_dot_c / c_dot_c) * cond
+                u_rej_c = uncond - u_on_c
+                displaced = cond + stretch * (cond - torch.clamp(u_dot_c / c_dot_c, min=0, max=1) * cond) - cond_scale * u_rej_c
+                logging.debug(f"NRS.nrs: displaced & stretched")
+
+                # squash displaced vector towards len(cond) based on squash scale
+                sq_len = torch.sum(displaced * displaced, dim=-1, keepdim=True)
+                squash_scale = (1 - squash) + squash * ((c_dot_c/sq_len) ** 0.5)
+                x_final = displaced * squash_scale
+                logging.debug(f"NRS.nrs: final")
+
+            return x_orig - (x - x_final * sigma / (sigma * sigma + 1.0) ** 0.5)
+        
+        m = model.clone()
+        m.set_model_sampler_cfg_function(nrs, True)
+        return (m, )
+
+NODE_CLASS_MAPPINGS = {
+    "NRS": NRS,
+}

--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -14,16 +14,15 @@ class NRS:
 
     CATEGORY = "advanced/model"
 
-    def patch(self, model, squash, stretch):
+    def patch(self, model, skew, stretch, squash):
         def nrs(args):
             cond = args["cond"]
             uncond = args["uncond"]
-            cond_scale = args["cond_scale"]
             sigma = args["sigma"]
             sigma = sigma.view(sigma.shape[:1] + (1,) * (cond.ndim - 1))
             x_orig = args["input"]
 
-            logging.debug(f"NRS.nrs: CFG: {cond_scale}, Squash: {squash}, Stretch: {stretch}")
+            logging.debug(f"NRS.nrs: Skew: {skew}, Stretch: {stretch}, Squash: {squash}")
 
             #rescale cfg has to be done on v-pred model output
             x = x_orig / (sigma * sigma + 1.0)
@@ -32,40 +31,146 @@ class NRS:
             logging.debug(f"NRS.nrs: generated cond and uncond")
 
             x_final = None
-            if False:
-                # displace cond by rejection of uncond on cond
-                u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                u_on_c = (u_dot_c / c_dot_c) * cond
-                u_rej_c = uncond - u_on_c
-                displaced = (cond - cond_scale * u_rej_c)
-                logging.debug(f"NRS.nrs: displaced")
+            match "v0.4.5":
+                case "v1":
+                    # displace cond by rejection of uncond on cond
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c = (u_dot_c / c_dot_c) * cond
+                    u_rej_c = uncond - u_on_c
+                    displaced = (cond - skew * u_rej_c)
+                    logging.debug(f"NRS.nrs: displaced")
 
-                # squash displaced vector towards len(cond) based on squash scale
-                sq_len = torch.sum(displaced * displaced, dim=-1, keepdim=True)
-                squash_scale = (1 - squash) + squash * ((c_dot_c/sq_len) ** 0.5)
-                squashed = displaced * squash_scale
-                logging.debug(f"NRS.nrs: squashed")
+                    # squash displaced vector towards len(cond) based on squash scale
+                    d_len_sq = torch.sum(displaced * displaced, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * ((c_dot_c/d_len_sq) ** 0.5)
+                    squashed = displaced * squash_scale
+                    logging.debug(f"NRS.nrs: squashed")
 
-                # stretch turned vector towards cond based on stretch scale
-                sq_dot_c = torch.sum(squashed * cond, dim=-1, keepdim=True)
-                sq_on_c = (sq_dot_c / c_dot_c) * cond
-                x_final = squashed + sq_on_c * stretch
-                logging.debug(f"NRS.nrs: final")
-            else:
-                # displace cond by rejection of uncond on cond
-                u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
-                c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
-                u_on_c = (u_dot_c / c_dot_c) * cond
-                u_rej_c = uncond - u_on_c
-                displaced = cond + stretch * (cond - torch.clamp(u_dot_c / c_dot_c, min=0, max=1) * cond) - cond_scale * u_rej_c
-                logging.debug(f"NRS.nrs: displaced & stretched")
+                    # stretch turned vector towards cond based on stretch scale
+                    sq_dot_c = torch.sum(squashed * cond, dim=-1, keepdim=True)
+                    sq_on_c = (sq_dot_c / c_dot_c) * cond
+                    x_final = squashed + sq_on_c * stretch
+                    logging.debug(f"NRS.nrs: final")
+                case "v2":
+                    # displace cond by rejection of uncond on cond
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    displaced = cond + stretch * (cond - torch.clamp(u_dot_c / c_dot_c, min=0, max=1) * cond) - skew * u_rej_c
+                    logging.debug(f"NRS.nrs: displaced & stretched")
 
-                # squash displaced vector towards len(cond) based on squash scale
-                sq_len = torch.sum(displaced * displaced, dim=-1, keepdim=True)
-                squash_scale = (1 - squash) + squash * ((c_dot_c/sq_len) ** 0.5)
-                x_final = displaced * squash_scale
-                logging.debug(f"NRS.nrs: final")
+                    # squash displaced vector towards len(cond) based on squash scale
+                    d_len_sq = torch.sum(displaced * displaced, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * ((c_dot_c/d_len_sq) ** 0.5)
+                    x_final = displaced * squash_scale
+                    logging.debug(f"NRS.nrs: final")
+                case "v3":
+                    # displace cond by rejection of uncond on cond
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    displaced = (cond - skew * u_rej_c)
+                    logging.debug(f"NRS.nrs: displaced")
+
+                    # squash displaced vector towards len(cond) based on squash scale
+                    d_len_sq = torch.sum(displaced * displaced, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * ((c_dot_c/d_len_sq) ** 0.5)
+
+                    # stretch vector towards 2*len(cond) - len(u_on_c)
+                    c_len = c_dot_c ** 0.5
+                    stretch_scale = (1 - stretch) + stretch * (2 * c_len - u_on_c_mag)/c_len
+
+                    x_final = displaced * squash_scale * stretch_scale
+                    logging.debug(f"NRS.nrs: final")
+                case "v4":
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    rej_dor_rej = torch.sum(u_rej_c * u_rej_c, dim=-1, keepdim=True)
+                    x_final = (cond - squash * u_rej_c + stretch * cond * ((rej_dor_rej/c_dot_c) ** 0.5))
+                    logging.debug(f"NRS.nrs: displaced")
+                case "v0.4.1":
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    rej_dor_rej = torch.sum(u_rej_c * u_rej_c, dim=-1, keepdim=True)
+                    stretched = cond + stretch * cond * ((rej_dor_rej/c_dot_c) ** 0.5)
+                    skewed = stretched - skew * u_rej_c
+                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * ((c_dot_c/sk_dot_sk) ** 0.5)
+                    x_final = skewed * squash_scale
+                    logging.debug(f"NRS.nrs: displaced")
+                case "v0.4.2":
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    proj_len = torch.sum(u_on_c * u_on_c, dim=-1, keepdim=True) ** 0.5
+                    cond_len = c_dot_c ** 0.5
+                    stretched = cond * (1 + stretch * torch.abs(cond_len - proj_len) / cond_len)
+                    skewed = stretched - skew * u_rej_c
+                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
+                    x_final = skewed * squash_scale
+                    logging.debug(f"NRS.nrs: displaced")
+                case "v0.4.3":
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    proj_len = torch.sum(u_on_c * u_on_c, dim=-1, keepdim=True) ** 0.5
+                    cond_len = c_dot_c ** 0.5
+                    stretched = cond * (1 + stretch * (cond_len - proj_len) / cond_len)
+                    skewed = stretched - skew * u_rej_c
+                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
+                    x_final = skewed * squash_scale
+                    logging.debug(f"NRS.nrs: displaced")
+                case "v0.4.4":
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    cond_len = c_dot_c ** 0.5
+                    proj_diff = cond - u_on_c
+                    proj_diff_len = torch.sum(proj_diff * proj_diff, dim=-1, keepdim=True) ** 0.5
+                    stretched = cond * (1 + stretch * proj_diff_len / cond_len)
+                    skewed = stretched - skew * u_rej_c
+                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
+                    x_final = skewed * squash_scale
+                    logging.debug(f"NRS.nrs: displaced")
+                case "v0.4.5":
+                    u_dot_c = torch.sum(uncond * cond, dim=-1, keepdim=True)
+                    c_dot_c = torch.sum(cond * cond, dim=-1, keepdim=True)
+                    u_on_c_mag = (u_dot_c / c_dot_c)
+                    u_on_c = u_on_c_mag * cond
+                    u_rej_c = uncond - u_on_c
+                    cond_len = c_dot_c ** 0.5
+                    proj_diff = cond - u_on_c
+
+                    # Amplify Cond based on length compared to projection of uncond
+                    stretched = cond + (stretch * proj_diff)
+
+                    # Skew/Steer Conf based on rejection of uncond on cond
+                    skewed = stretched - skew * u_rej_c
+
+                    # Squash final length back down to original length of cond
+                    sk_dot_sk = torch.sum(skewed * skewed, dim=-1, keepdim=True)
+                    squash_scale = (1 - squash) + squash * cond_len / (sk_dot_sk ** 0.5)
+                    x_final = skewed * squash_scale
 
             return x_orig - (x - x_final * sigma / (sigma * sigma + 1.0) ** 0.5)
         

--- a/README.md
+++ b/README.md
@@ -6,4 +6,22 @@ This is accomplised in 3 steps:
 2. **Squashing**: The displaced tensor is rescaled towards the original length of the conditioned tensor. This means for high displacement scaling values the tensor 'turns' away from the unconditioned direction, which for very negative displacements, it turns towards the unconditioned tensor. 0 displacement outputs the original conditioned tensor.
 3. **Stretching**: The post-squash 'steered' tensor is stretched towards the direction of the original conditioned tensor. The more sharp the steering the less pronounced the stretch is, with fully aligned tensors being stretched the full stretch scale parameter. 1x stretch adds 100% length to the tensor.
 
-# Examples (TODO)
+# Alpha Release
+Implements NRS with Skew, Stretch, and Squash parameters.
+
+## Parameters
+Skew and Stretch are roughly similar to CFG, but decomposed, with `Stretch + Skew = CFG`, roughly.
+
+**Skew** changes the 'direction' of generation, which should result in changes to the content and composition of the image.
+**Stretch** changes to 'amplification' of generation, which should result in stronger prompt representation.
+**Squash** 'normalizes' the resulting guidance back towards the original amplitude with 1.0 being the same amplitude, while 0.0 is the unmodified amplitude resulting from the Squash and Stretch functions.
+
+## Beginner How-To
+1. Set Squash to 0.0
+2. Set Skew & Stretch each to 1/2 your normal CFG Scale setting
+3. Test some generation. Results should be 'similar' in quality to CFG
+4. Adjust Skew up/down to change content and composition
+5. Adjust Stretch up/down to change strength of image aspects and colors
+6. Adjust Squash up to remove artifacts and color burn (these will tend to be replaced by additional or extraneous details and elements)
+
+**Tip**: You can experiment with negative values for Skew and Stretch as well to see what the model 'believes' your negative prompt 'means'.

--- a/scripts/negative_rejection_steering_script.py
+++ b/scripts/negative_rejection_steering_script.py
@@ -1,0 +1,126 @@
+import gradio as gr
+import logging
+import sys
+from functools import partial
+from modules import scripts, script_callbacks
+from typing import Any
+
+from NRS.nodes_NRS import NRS
+
+class NRSScript(scripts.Script):
+    def __init__(self):
+        super().__init__()
+        self.enabled = False
+        self.squash = 0.5
+        self.stretch = 1.0
+
+    sorting_priority = 5
+
+    def title(self):
+        return "Negative Rejection Steering for reForge"
+
+    def show(self, is_img2img):
+        return scripts.AlwaysVisible
+    
+    def ui(self, *args, **kwargs):
+        with gr.Accordion(open=False, label=self.title()):
+            gr.HTML("<p><i>Adjust the settings for Negative Rejection Steering.</i></p>")
+            enabled = gr.Checkbox(label="Enable NRS", value=self.enabled)
+            squash = gr.Slider(label="NRS Squash Multiplier", minimum=0.0, maximum=1.0, step=0.01, value=self.squash)
+            stretch = gr.Slider(label="NRS Stretch Multiplier", minimum=-1.0, maximum=30.0, step=0.01, value=self.stretch)
+
+        enabled.change(
+            lambda x: self.update_enabled(x),
+            inputs=[enabled]
+        )
+
+        return (enabled, squash, stretch)
+    
+
+    def update_enabled(self, value):
+        self.enabled = value
+
+    def process_before_every_sampling(self, p, *args, **kwargs):
+        if len(args) >= 3:
+            self.enabled, self.squash, self.stretch = args[:3]
+        else:
+            logging.warning("Not enough arguments provided to process_before_every_sampling")
+            return
+
+        xyz = getattr(p, "_nrs_xyz", {})
+        if "enabled" in xyz:
+            self.enabled = xyz["enabled"] == "True"
+        if "squash" in xyz:
+            self.squash = xyz["squash"]
+        if "stretch" in xyz:
+            self.stretch = xyz["stretch"]
+
+        # Always start with a fresh clone of the original unet
+        unet = p.sd_model.forge_objects.unet.clone()
+
+        if not self.enabled:
+            # Reset the unet to its original state
+            p.sd_model.forge_objects.unet = unet
+            return
+
+        unet = NRS().patch(unet, self.squash, self.stretch)[0]
+
+        p.sd_model.forge_objects.unet = unet
+        p.extra_generation_params.update({
+            "NRS_enabled": True,
+            "NRS_squash": self.squash,
+            "NRS_stretch": self.stretch,
+        })
+
+        logging.debug(f"NRS: Enabled: {self.enabled}, Squash: {self.squash}, Stretch: {self.stretch}")
+
+        return
+
+def set_value(p, x: Any, xs: Any, *, field: str):
+    if not hasattr(p, "_nrs_xyz"):
+        p._nrs_xyz = {}
+    p._nrs_xyz[field] = x
+
+def make_axis_on_xyz_grid():
+    xyz_grid = None
+    for script in scripts.scripts_data:
+        if script.script_class.__module__ == "xyz_grid.py":
+            xyz_grid = script.module
+            break
+
+    if xyz_grid is None:
+        return
+
+    axis = [
+        xyz_grid.AxisOption(
+            "(NRS) Enabled",
+            str,
+            partial(set_value, field="enabled"),
+            choices=lambda: ["True", "False"]
+        ),
+        xyz_grid.AxisOption(
+            "(NRS) Squash",
+            float,
+            partial(set_value, field="squash"),
+        ),
+        xyz_grid.AxisOption(
+            "(NRS) Stretch",
+            float,
+            partial(set_value, field="stretch"),
+        ),
+    ]
+
+    if not any(x.label.startswith("(NRS)") for x in xyz_grid.axis_options):
+        xyz_grid.axis_options.extend(axis)
+
+def on_before_ui():
+    try:
+        make_axis_on_xyz_grid()
+    except Exception:
+        error = traceback.format_exc()
+        print(
+            f"[-] NRS Script: xyz_grid error:\n{error}",
+            file=sys.stderr,
+        )
+
+script_callbacks.on_before_ui(on_before_ui)


### PR DESCRIPTION
# Alpha Release
Implements NRS with Skew, Stretch, and Squash parameters.

## Parameters
Skew and Stretch are roughly similar to CFG, but decomposed, with `Stretch + Skew = CFG`, roughly.

**Skew** changes the 'direction' of generation, which should result in changes to the content and composition of the image.
**Stretch** changes to 'amplification' of generation, which should result in stronger prompt representation.
**Squash** 'normalizes' the resulting guidance back towards the original amplitude with 1.0 being the same amplitude, while 0.0 is the unmodified amplitude resulting from the Squash and Stretch functions.

## Beginner How-To
1. Set Squash to 0.0
2. Set Skew & Stretch each to 1/2 your normal CFG Scale setting
3. Test some generation. Results should be 'similar' in quality to CFG
4. Adjust Skew up/down to change content and composition
5. Adjust Stretch up/down to change strength of image aspects and colors
6. Adjust Squash up to remove artifacts and color burn (these will tend to be replaced by additional or extraneous details and elements)

**Tip**: You can experiment with negative values for Skew and Stretch as well to see what the model 'believes' your negative prompt 'means'.