### PR TITLE
Add `flux` to the Prediction Type inference

### DIFF
--- a/NRS/nodes_NRS.py
+++ b/NRS/nodes_NRS.py
@@ -13,6 +13,7 @@ class PredictionType(Enum):
 _RAW_TO_ENUM = {
     "eps":          PredictionType.EPS,
     "epsilon":      PredictionType.EPS,
+    "flux":         PredictionType.EPS,
     "v":            PredictionType.V,
     "v_prediction": PredictionType.V,
     "x0":           PredictionType.X0,


### PR DESCRIPTION
Testing it in Comfy, it seems like it works as `EPS`, though it also worked with `V`.